### PR TITLE
Don't ignore backend load issue silently

### DIFF
--- a/cordova-non-renewing-subscription.js
+++ b/cordova-non-renewing-subscription.js
@@ -432,7 +432,7 @@
     // Change cached value of the expiry date.
     // Trigger "onChange" if the value has changed.
     var setExpiryDate = function(value) {
-      if (this.expiryDate !== value) {
+      if (!isNaN(value) && value !=== null && this.expiryDate !== value) {
         this.expiryDate = value;
         if (this.onChange) {
           setTimeout(this.onChange, 0);

--- a/cordova-non-renewing-subscription.js
+++ b/cordova-non-renewing-subscription.js
@@ -432,7 +432,7 @@
     // Change cached value of the expiry date.
     // Trigger "onChange" if the value has changed.
     var setExpiryDate = function(value) {
-      if (!isNaN(value) && value !=== null && this.expiryDate !== value) {
+      if (!isNaN(value) && value !== null && this.expiryDate !== value) {
         this.expiryDate = value;
         if (this.onChange) {
           setTimeout(this.onChange, 0);

--- a/cordova-non-renewing-subscription.js
+++ b/cordova-non-renewing-subscription.js
@@ -358,7 +358,7 @@
         });
       }
       else {
-        cb(null, {
+        cb(err, {
           expiryDate: null,
           expiryTimestamp: null,
           subscriber: false,


### PR DESCRIPTION
Two issues with loadExpiryDate function failing, for example, because of connectivity problems:
- If loadExpiryDate failed, the error should be visible to the callback function. 
- If loadExpiryDate failed, the onChange event got fired repeatedly because NaN !== NaN 
