### PR TITLE
Configurable parent element for the dialog view

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ When a user logs in or out, you will want to reset the expiry date cached by the
 
 To do so, just call `nonRenewing.reset();`.
 
+### Dialog options
+
+At initialization you can provide the html element that should hold the In-App Purchase dialog.
+
+```js
+nonRenewing.initialize({
+    ...
+    dialog: {
+      parent: document.querySelectorAll('.order-form')[0]
+    }
+});
+
+```
+
 ### Author / Copyright
 
 This code is published under the MIT license.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Available options:
  * `verbosity`. Default to `store.INFO`. See the cordova purchase plugin for possible value.
  * `loadExpiryDate`. Default to a function that loads from localStorage. See the related section on how to load the subscription status on your server.
  * `saveExpiryDate`. Default to a function that saves to localStorage. See the related section on how to save the subscription status on your server.
+ * `dialog`. Holds UI options for the In-App Purchase dialog.
+   - `parent`. Default to `document.body`. Parent HTML element to which to attach the In-App Purchase dialog.
 
 #### nonRenewing.openSubscriptionManager()
 

--- a/cordova-non-renewing-subscription.js
+++ b/cordova-non-renewing-subscription.js
@@ -481,7 +481,9 @@
 
   nonRenewing.initialize = function(options) {
 
-    this.view = new View(document.body);
+    options.dialog = options.dialog || {};
+
+    this.view = new View(options.dialog.parent || document.body);
 
     if (!window.store) {
       this.view.showError('The in-app purchase plugin is not available.');


### PR DESCRIPTION
By default the dialog is attached to 'document.body'. This seems to be a problem with some frameworks, i.e., Ionic 1.3.
One may now pass the parent element as a 'dialog.parent' option.

Example:
```javascript
      nonRenewing.initialize({
        dialog: {
          parent: document.querySelectorAll('.my-view')[0]
        },
```

Should also fix issue #10.
