### PR TITLE
Add z-index to root div.

### DIFF
--- a/cordova-non-renewing-subscription.js
+++ b/cordova-non-renewing-subscription.js
@@ -50,6 +50,7 @@
       this.el.style.left = 0;
       this.el.style.right = 0;
       this.el.style.backgroundColor = 'rgba(0,0,0,0.5)';
+      this.el.style['z-index'] = 99999999999;
       this.hide();
       parent.appendChild(this.el);
   };


### PR DESCRIPTION
After installing the plugin, I didn't see the root div. This fixes that by adding a high z-index on the div. Because this is a "system" dialog, it seems reasonable to have a really high value.